### PR TITLE
doc(base): riak_core ➞ riak_core_console

### DIFF
--- a/0_base_project/elixir/README.md
+++ b/0_base_project/elixir/README.md
@@ -9,14 +9,14 @@ To run:
 
     mix deps.get
     MIX_ENV=dev_a iex --name dev_a@127.0.0.1 -S mix
-    iex> :riak_core.member_status([])
+    iex> :riak_core_console.member_status([])
 
 To build a cluster, start another member and join it to the cluster:
 
     # In another terminal
     MIX_ENV=dev_b iex --name dev_b@127.0.0.1 -S mix
     iex> :riak_core.join('dev_a@127.0.0.1')
-    iex> :riak_core.member_status([])
+    iex> :riak_core_console.member_status([])
 
 Now you have a cluster!
 

--- a/1_plain_hash/elixir/lib/simple_hash/service.ex
+++ b/1_plain_hash/elixir/lib/simple_hash/service.ex
@@ -9,6 +9,6 @@ defmodule SimpleHash.Service do
     [{index_vnode, _type}] = pref_list
     # then actually send the request to that vnode
     # (riak core appends "_master" to SimpleHash.Vnode for a process name, hence the weirdness)
-    :riak_core_vnode_master.sync_spawn_command(index_node, :ping, SimpleHash.Vnode_master)
+    :riak_core_vnode_master.sync_spawn_command(index_vnode, :ping, SimpleHash.Vnode_master)
   end
 end

--- a/3_coordinated_kv/elixir/lib/coordinated_kv/op_fsm.ex
+++ b/3_coordinated_kv/elixir/lib/coordinated_kv/op_fsm.ex
@@ -6,9 +6,9 @@ defmodule CoordinatedKV.OpFSM do
   end
 
   def op(op, key, n, w) do
-	req_id = req_id()
-	CoordinatedKV.OpFSM.Sup.start_op_fsm([req_id, self(), op, key, n, w])
-	{:ok, req_id}
+  	req_id = req_id()
+  	CoordinatedKV.OpFSM.Sup.start_op_fsm([req_id, self(), op, key, n, w])
+  	{:ok, req_id}
   end
 
   # FSM callbacks

--- a/6_chat/elixir/apps/zap_frontend/config/dev.exs
+++ b/6_chat/elixir/apps/zap_frontend/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :zap_frontend,
+  port: 4039


### PR DESCRIPTION
corrects README for base project (Elixir) so it uses `riak_core_console` for member_status
